### PR TITLE
Fix issue #12: usage of array method name (join, shift, unshift, ...) as topic part

### DIFF
--- a/index.js
+++ b/index.js
@@ -129,7 +129,9 @@ function removeAllListeners (topic) {
     this._listeners.set(topicString, [])
     this.onremove(topicString)
   } else {
-    var topicStrings = this._listeners.query('#').map(function (listeners) {
+    var topicStrings = this._listeners.query('#').filter(function (listeners) {
+        return listeners && listeners.length > 0
+      }).map(function (listeners) {
       return MQTTPattern.clean(listeners[0].pattern)
     })
 

--- a/package.json
+++ b/package.json
@@ -26,13 +26,13 @@
   },
   "homepage": "https://github.com/RangerMauve/mqtt-emitter",
   "devDependencies": {
-    "browserify": "^5.11.1",
+    "browserify": "^16.5.0",
     "node-noop": "0.0.1",
     "tape": "^4.5.1",
     "uglify-js": "^2.4.15"
   },
   "dependencies": {
     "mqtt-pattern": "^1.2.0",
-    "mqtt-store": "^1.0.2"
+    "mqtt-store": "^2.1.0"
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -92,6 +92,27 @@ test('MQTTEmitter#removeAllListeners:should remove all listeners when no topic i
   }
 })
 
+test('MQTTEmitter#removeAllListeners:should remove all listeners even if there are already no more listeners', function (t) {
+  var emitter = new MQTTEmitter()
+  var topicPrefix = 'test/remove/all'
+  emitter
+    .on(topicPrefix + '1', fn)
+    .on(topicPrefix + '2', fn)
+    .on(topicPrefix + '3', fn)
+    .removeListener(topicPrefix + '1', fn)
+    .removeAllListeners()
+
+  emitter.emit(topicPrefix + '1', 'test')
+  emitter.emit(topicPrefix + '2', 'test')
+  emitter.emit(topicPrefix + '3', 'test')
+
+  t.end()
+
+  function fn () {
+    t.end(new Error('Listener was not removed'))
+  }
+})
+
 test('MQTTEmitter#emit(): should call listeners', function (t) {
   var emitter = new MQTTEmitter()
   emitter.on('test/emit/1', function () {

--- a/test/index.js
+++ b/test/index.js
@@ -182,6 +182,16 @@ test('MQTTEmitter#emit(): should supply original topic pattern as fourth argumen
   emitter.emit('test/emit/4')
 })
 
+test('MQTTEmitter#emit(): should support array method as topic part (issue #11)', function (t) {
+  t.plan(1)
+  var emitter = new MQTTEmitter()
+  emitter.removeAllListeners()
+  emitter.on('test/emit/+middle/+end', function (payload, params, topic, pattern) {
+    t.equal(pattern, 'test/emit/+middle/+end', 'fourth argument is the pattern')
+  })
+  emitter.emit('test/emit/shift/join')
+})
+
 test('MQTTEmitter#once:should only invoke callback once', function (t) {
   t.plan(1)
   var emitter = new MQTTEmitter()


### PR DESCRIPTION
This issue is fixed by upgrading the mqtt-store to the last version 2.1.0.

A test has been added to reproduce the issue, the upgrade of mqtt-store has been done, and the test is no more failing. The API change of underlying library has been integrated without any impact on mqtt-emitter API