### PR TITLE
Fix README custom callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,10 +72,10 @@ There are also hooks that you can listen for new and removed topic listeners.
 ``` javascript
 // Override the default behavior with a custom callback for subscribing to topics
 emitter.onadd = function (topic) {
-	mqtt.subscribe("topic");
+	mqtt.subscribe(topic);
 }
 emitter.onremove = function (topic) {
-	mqtt.unsubscribe("topic");
+	mqtt.unsubscribe(topic);
 }
 ```
 


### PR DESCRIPTION
The custom callback for **"onadd"** and  **"onremove"** example souds like it should automatically subscribe to topic added on the events but it actually only subscribes to the constant topic **"topic"**.